### PR TITLE
Use Proxy Chain only with Proxy

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,6 +48,8 @@ if [ ! -z $http_proxy ]; then
         exit 1
     fi
 
+    /docker/proxify.sh /usr/local/bin/entrypoint.sh -f /etc/squid/squid.conf -NYC
+else
+    /usr/local/bin/entrypoint.sh -f /etc/squid/squid.conf -NYC
 fi
 
-/docker/proxify.sh /usr/local/bin/entrypoint.sh -f /etc/squid/squid.conf -NYC


### PR DESCRIPTION
If the proxy is left empty, the server will try to connect to "PROXYIP" "PROXYPORT" for every request, resulting in connection issues. Therefore, we should only use proxify.sh then the http_proxy variable is set.