### PR TITLE
fix: Replaced Anonymous Volume with mkdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu/squid:latest
-VOLUME ["/docker/custom-certs"]
 ADD ./entrypoint.sh ./proxify.sh /docker/
 RUN apt-get update -y && apt-get install -y \
     proxychains4 \
     && rm -rf /var/lib/apt/lists/*
 RUN sed -i 's/^# localnet /localnet /;s/^socks.*$/#http PROXYIP PROXYPORT/' /etc/proxychains4.conf
-RUN chmod +x /docker/entrypoint.sh /docker/proxify.sh
+RUN mkdir /docker/custom-certs; \
+    chmod +x /docker/entrypoint.sh /docker/proxify.sh
 ENTRYPOINT ["/docker/entrypoint.sh"]


### PR DESCRIPTION
The Volume Statement caused the creation of multiple unnamed and empty Volumes at servers.