### PR TITLE
Stop with SIGKILL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,8 @@ RUN apt-get update -y && apt-get install -y \
 RUN sed -i 's/^# localnet /localnet /;s/^socks.*$/#http PROXYIP PROXYPORT/' /etc/proxychains4.conf
 RUN mkdir /docker/custom-certs; \
     chmod +x /docker/entrypoint.sh /docker/proxify.sh
+    
+# This is necessary as the upstream image won't forward a SIGINT/SIGTERM correctly.
+STOPSIGNAL SIGKILL
+
 ENTRYPOINT ["/docker/entrypoint.sh"]


### PR DESCRIPTION
Stopping with SIGKILL is okay for a proxy without persistence and required as the upstream container does not correctly forward Docker's signal.