### PR TITLE
Adapt to current samply docker-ci workflow

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -38,7 +38,7 @@ jobs:
       #   foo: bar
       # If your actions generate an artifact in a previous build step, you can tell this workflow to download it
       # artifact-name: '' # the default '' doesn't try to download an artifact
-      push-to: dockerhub
+      push-to: docker.io
     # This passes the secrets from calling workflow to the called workflow
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
The current version of the samply docker-ci workflow does not support `dockerhub` as a target but changed it to `docker.io`. This PR restores compatibility.