### PR TITLE
Remove Proxychains

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,9 @@
 FROM ubuntu/squid:latest
-ADD ./entrypoint.sh ./proxify.sh /docker/
+ADD ./entrypoint.sh /docker/
 ADD dont_write_to_disk.conf /etc/squid/conf.d/
-RUN apt-get update -y && apt-get install -y \
-    proxychains4 \
-    && rm -rf /var/lib/apt/lists/*
-RUN sed -i 's/^# localnet /localnet /;s/^socks.*$/#http PROXYIP PROXYPORT/' /etc/proxychains4.conf
 RUN mkdir /docker/custom-certs; \
-    chmod +x /docker/entrypoint.sh /docker/proxify.sh
-    
+    chmod +x /docker/entrypoint.sh
+
 # This is necessary as the upstream image won't forward a SIGINT/SIGTERM correctly.
 STOPSIGNAL SIGKILL
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Bridgehead Forward Proxy
 The target of this project is to provide a local service for components running inside restricted networks, that will handle all communication with corporate proxy. Therefore, components that can't handle different kind of proxys well by them selfe, can just refer to this standard proxy inside their docker network, and the bridgehead forward proxy will handle the rest.
-The bridgehead forward proxy is a customized version of the squid cache proxy. Additionally, all communication of this proxy will wrap with proxy chains if a proxy is configured.
+The bridgehead forward proxy is a customized version of the squid cache proxy, communication, if configured, via an upstream parent proxy.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,35 +68,18 @@ if [ ! -z $https_proxy ]; then
     fi
 
 
-
-    IP=""
-    if [[ $HOST =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        IP="$HOST"
-      else
-        IP="$(getent hosts $HOST | cut -d ' ' -f 1 | tail -1)"
-    fi
-
-    LINE="http $IP $PORT"
     SQUID_LINE="cache_peer $HOST parent $PORT 0 no-query default"
 
     if [ ! -z $PROXY_PASSWORD ]; then
-        echo "Using proxy at $IP:$PORT with username $PROXY_USERNAME and password (hidden)."
+        echo "Using proxy at $HOST:$PORT with username $PROXY_USERNAME and password (hidden)."
         PROXY_PASSWORD_ESCAPED=$(urldecode "$PROXY_PASSWORD")
-        LINE+=" $PROXY_USERNAME $PROXY_PASSWORD_ESCAPED"
-	SQUID_LINE+=" login=$PROXY_USERNAME:$PROXY_PASSWORD_ESCAPED"
+    	SQUID_LINE+=" login=$PROXY_USERNAME:$PROXY_PASSWORD_ESCAPED"
     else
-        echo "Using proxy at $IP:$PORT without authentication."
+        echo "Using proxy at $HOST:$PORT without authentication."
     fi
 
-    cat /etc/proxychains4.conf > /tmp/proxychains4.conf
-    echo "$LINE" >> /tmp/proxychains4.conf
     echo "$SQUID_LINE" > /etc/squid/conf.d/50-parent.conf
-
-    if [ "proxychains-is-happy" != "$(/docker/proxify.sh echo proxychains-is-happy)" ]; then
-        echo "Error: Failed to configure proxychains with proxy $https_proxy (= https_proxy)"
-        exit 1
-    fi
 
 fi
 
-exec /docker/proxify.sh /usr/local/bin/entrypoint.sh -f /etc/squid/squid.conf -NYC
+exec /usr/local/bin/entrypoint.sh -f /etc/squid/squid.conf -NYC

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,27 @@
 #!/usr/bin/env bash
 
-## All credit to https://stackoverflow.com/questions/6250698/how-to-decode-url-encoded-string-in-shell
-function urldecode() { : "${*//+/ }"; echo -e "${_//%/\\x}"; }
+urldecode() {
+    local output=""
+    local i=0
+    local len=${#1}
+
+    while (( i < len )); do
+        local c="${1:i:1}"
+
+        if [[ "$c" == "%" && $((i+2)) -lt len ]]; then
+            local hex="${1:i+1:2}"
+            if [[ "$hex" =~ ^[0-9A-Fa-f]{2}$ ]]; then
+                output+=$(printf "\\x$hex")
+                ((i+=3))
+                continue
+            fi
+        fi
+	output+="$c"
+
+        ((i++))
+    done
+    printf '%s' "$output"
+}
 
 OPTIONS=""
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,17 +77,20 @@ if [ ! -z $https_proxy ]; then
     fi
 
     LINE="http $IP $PORT"
+    SQUID_LINE="cache_peer $HOST parent $PORT 0 no-query default"
 
     if [ ! -z $PROXY_PASSWORD ]; then
         echo "Using proxy at $IP:$PORT with username $PROXY_USERNAME and password (hidden)."
         PROXY_PASSWORD_ESCAPED=$(urldecode "$PROXY_PASSWORD")
         LINE+=" $PROXY_USERNAME $PROXY_PASSWORD_ESCAPED"
+	SQUID_LINE+=" login=$PROXY_USERNAME:$PROXY_PASSWORD_ESCAPED"
     else
         echo "Using proxy at $IP:$PORT without authentication."
     fi
 
     cat /etc/proxychains4.conf > /tmp/proxychains4.conf
     echo "$LINE" >> /tmp/proxychains4.conf
+    echo "$SQUID_LINE" > /etc/squid/conf.d/50-parent.conf
 
     if [ "proxychains-is-happy" != "$(/docker/proxify.sh echo proxychains-is-happy)" ]; then
         echo "Error: Failed to configure proxychains with proxy $https_proxy (= https_proxy)"

--- a/proxify.sh
+++ b/proxify.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-if [ -e /tmp/proxychains4.conf ]; then
-  exec proxychains -f /tmp/proxychains4.conf $@
-else
-  exec $@
-fi


### PR DESCRIPTION
By using a proper squid upstream proxy configuration, we possibly don't need proxychains anymore.
This PR is not intended for merging, but for triggering the CI and thoroughly test the image at the sites.